### PR TITLE
Fix write dword reg with bits 31:12 all set

### DIFF
--- a/test/tqv.py
+++ b/test/tqv.py
@@ -109,7 +109,7 @@ class TinyQV:
         await test_util.stop_nops()
 
         # Prepare value for LUI + ADDI
-        value_upper = (value + 0x800) >> 12
+        value_upper = ((value + 0x800) >> 12) & 0xfffff
         value_lower = value & 0xfff
         if value_lower >= 0x800:
             value_lower -= 0x1000


### PR DESCRIPTION
To write a dword to a memory mapped register, the testbench wrapper was constructing an lui + addi pair, but was not masking the immediate value for lui. In the case where bits 31:12 were all set in the value being written, the calculation of the immediate value for lui would be outside of the representable range, which would cause InstructionLUI to throw an exception.

This change fixes the issue by masking the calculated immediate value into the representable range. The calculation itself was already correct, so does not need any further modification. For example if value = 0xFFFFFFFF, then (value + 0x800) >> 12 = 0x100000. Masking this value into the representable range means value_upper = 0. This is correct, since value_lower = (0xfff - 0x1000) = -1, which results in lui setting the register to 0, and then addi adding -1 to 0, resulting in -1 or 0xFFFFFFFF.