### PR TITLE
Add WatchDog Timer peripheral

### DIFF
--- a/docs/user_peripherals/06_wdt.md
+++ b/docs/user_peripherals/06_wdt.md
@@ -1,0 +1,52 @@
+# WatchDog Timer
+
+Author: Niklas Anderson
+
+Peripheral index: 06
+
+## What it does
+
+The watchdog timer (WDT) peripheral provides a mechanism to detect software lockups or system hangs. Once started, it begins counting down from a configured value. If the countdown reaches zero without being "tapped", the WDT asserts an interrupt (`user_interrupt`) to signal a system fault.
+
+A tap entails writing a specified value (0xABCD) to address 0x3. This is designed to reduce the likelihood of an inadvertent clearing of the interrupt due to corrupt or misbehaving signals. Besides the tap action, only a reset will clear the interrupt.
+
+## Register map
+
+| Address | Name       | Access | Description                                                                 |
+|---------|------------|--------|-----------------------------------------------------------------------------|
+|  0x0  | ENABLE     | W      | Write 1 to enable the watchdog, 0 to disable. Does not clear timeout.       |
+|  0x1  | START      | W      | Starts the watchdog (also enables). Has no effect if countdown = 0.         |
+|  0x2  | COUNTDOWN  | R/W    | Sets or reads the countdown value (in clock cycles). 8/16/32-bit writes allowed. |
+|  0x3  | TAP        | W      | Write 0xABCD to reset countdown and clear timeout, only if enabled and started. |
+|  0x4  | STATUS     | R      | Bit 0: enabled, Bit 1: started, Bit 2: timeout_pending, Bit 3: counter active |
+
+
+## How to test
+
+The WDT is configured and interacted with through memory-mapped registers using byte/half-word/word writes, with countdown resolution based on the system clock (typically 64 MHz). Configuration on system startup requires writing a countdown value to the peripheral, then starting the counter by writing to the start address. The countdown begins immediately, and proceeds until reaching zero or receiving the correct pre-specified value (0xABCD) at the tap address. If the countdown reaches zero before receiving a valid tap, the `user_interrupt` signal is asserted. If a valid tap is recieved, the countdown is restarted and any existing interrupt is de-asserted.
+
+The timer may be disabled by writing a 0 to the enable address. When re-starting the timer by writing to the start address, the counter is reset to the saved countdown value. If no countdown value has been set, the timer will not start.
+
+A typical test covering standard expected functionality should include:
+- Bring the `rst_n` reset signal low
+- Write a countdown value in clock ticks to the countdown address (0x2)
+- Write any value to the start address (0x1)
+- Write the tap value 0xABCD to the tap address (0x3) before the number of clock cycles previously set has elapsed
+- Confirm that the `user_interrupt` signal has not been asserted
+- Continue writing to the tap address in order to prevent or clear the interrupt
+
+Tests using the `tt_um_tqv_peripheral_harness.v` may be run with the following command:
+```sh
+make -B
+```
+
+Examples of possible countdown values include the following, assuming a 64MHz clock frequency (15.625ns clock period):
+|  Time  |  Hex Value  |
+|--------|-------------|
+|  10ms  |  0x0009C400 |
+|    1s  |  0x03D09000 |
+|   60s  |  0xE4E1C000 |
+
+## External hardware
+
+None

--- a/info.yaml
+++ b/info.yaml
@@ -50,6 +50,7 @@ project:
     - "user_peripherals/baby_vga/framebuffer.v"
     - "user_peripherals/baby_vga/vga_timing.v"
     - "user_peripherals/baby_vga/peripheral.v"
+    - "user_peripherals/wdt/tqvp_nkanderson_wdt.sv"
     - "tinyQV/cpu/tinyqv.v"
     - "tinyQV/cpu/alu.v"
     - "tinyQV/cpu/core.v"

--- a/src/peripherals.v
+++ b/src/peripherals.v
@@ -27,7 +27,7 @@ module tinyQV_peripherals (
     // Data read and write requests from the TinyQV core.
     input [1:0]   data_write_n, // 11 = no write, 00 = 8-bits, 01 = 16-bits, 10 = 32-bits
     input [1:0]   data_read_n,  // 11 = no read,  00 = 8-bits, 01 = 16-bits, 10 = 32-bits
-    
+
     output [31:0] data_out,     // Data out from the peripheral, bottom 8, 16 or all 32 bits are valid on read when data_ready is high.
     output        data_ready,
 
@@ -62,8 +62,8 @@ module tinyQV_peripherals (
     assign uo_out = uo_out_comb;
 
     // Register the data output from the peripheral.  This improves timing and
-    // also simplifies the peripheral interface (no need for the peripheral to care 
-    // about holding data_out until data_read_complete - it looks like it is read 
+    // also simplifies the peripheral interface (no need for the peripheral to care
+    // about holding data_out until data_read_complete - it looks like it is read
     // synchronously).
     always @(posedge clk) begin
         if (!rst_n) begin
@@ -156,7 +156,7 @@ module tinyQV_peripherals (
                 end else begin
                     uo_out_comb[i] = uo_out_from_user_peri[gpio_out_func_sel[i][3:0]][i];
                 end
-            end            
+            end
         end
     endgenerate
 
@@ -228,7 +228,7 @@ module tinyQV_peripherals (
         .user_interrupt(user_interrupts[5])
     );
 
-    tqvp_full_example i_user_peri06 (
+    tqvp_nkanderson_wdt i_user_peri06 (
         .clk(clk),
         .rst_n(rst_n),
 
@@ -511,7 +511,7 @@ module tinyQV_peripherals (
 
         .data_out(data_from_simple_peri[5])
     );
-    
+
     tqvp_spike spike(
         .clk(clk),
         .rst_n(rst_n),
@@ -525,7 +525,7 @@ module tinyQV_peripherals (
 
         .data_out(data_from_simple_peri[6])
     );
-    
+
 
     tqvp_byte_example i_user_simple07 (
         .clk(clk),

--- a/src/user_peripherals/wdt/tqvp_nkanderson_wdt.sv
+++ b/src/user_peripherals/wdt/tqvp_nkanderson_wdt.sv
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2025 Niklas Anderson
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+`default_nettype none
+
+
+module tqvp_nkanderson_wdt (
+    input         clk,          // Clock - the TinyQV project clock is normally set to 64MHz.
+    input         rst_n,        // Reset_n - low to reset.
+
+    input  [7:0]  ui_in,        // The input PMOD, always available.  Note that ui_in[7] is normally used for UART RX.
+                                // The inputs are synchronized to the clock, note this will introduce 2 cycles of delay on the inputs.
+
+    output [7:0]  uo_out,       // The output PMOD.  Each wire is only connected if this peripheral is selected.
+                                // Note that uo_out[0] is normally used for UART TX.
+
+    input [5:0]   address,      // Address within this peripheral's address space
+    input [31:0]  data_in,      // Data in to the peripheral, bottom 8, 16 or all 32 bits are valid on write.
+
+    // Data read and write requests from the TinyQV core.
+    input [1:0]   data_write_n, // 11 = no write, 00 = 8-bits, 01 = 16-bits, 10 = 32-bits
+    input [1:0]   data_read_n,  // 11 = no read,  00 = 8-bits, 01 = 16-bits, 10 = 32-bits
+
+    output [31:0] data_out,     // Data out from the peripheral, bottom 8, 16 or all 32 bits are valid on read when data_ready is high.
+    output        data_ready,
+
+    output        user_interrupt  // Dedicated interrupt request for this peripheral
+);
+
+    // ------------------------------------------------------------------------
+    // Internal Registers and Parameters
+    // ------------------------------------------------------------------------
+    localparam TAP_MAGIC = 32'h0000ABCD;  // reduce likelihood of corrupt data inadvertently signalling tap
+    // Register address map
+    localparam ADDR_ENABLE = 6'd0;
+    localparam ADDR_START = 6'd1;
+    localparam ADDR_COUNTDOWN = 6'd2;
+    localparam ADDR_TAP = 6'd3;
+    localparam ADDR_STATUS = 6'd4;
+
+    logic [31:0] countdown_value;  // configured reload value
+    logic [31:0] counter;  // countdown timer
+
+    logic        enabled;  // written at address 0 or implied by start
+    logic        started;  // set by write to address 1
+    logic        timeout_pending;  // true if timer expired and interrupt is active
+
+    logic [31:0] data_reg;  // output data
+    logic        data_ready_reg;
+
+    // ------------------------------------------------------------------------
+    // Write Handling
+    // ------------------------------------------------------------------------
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            enabled         <= 1'b0;
+            started         <= 1'b0;
+            countdown_value <= 32'd0;
+            counter         <= 32'd0;
+            timeout_pending <= 1'b0;
+        end else begin
+            // Countdown logic
+            if (enabled && started && !timeout_pending) begin
+                if (counter > 0) counter <= counter - 1;
+                if (counter == 1) timeout_pending <= 1'b1;  // triggers interrupt on next clk
+            end
+
+            // Handle writes
+            if (data_write_n != 2'b11) begin
+                unique case (address)
+                    ADDR_ENABLE: begin  // Enable
+                        // Note: Does not clear timeout, but countdown and started state are preserved
+                        enabled <= data_in[0];
+                    end
+
+                    ADDR_START: begin  // Start
+                        // Start implicitly enables
+                        if (countdown_value != 0) begin
+                            enabled <= 1'b1;
+                            started <= 1'b1;
+                            counter <= countdown_value;
+                        end
+                    end
+
+                    ADDR_COUNTDOWN: begin  // Set countdown value
+                        unique case (data_write_n)
+                            2'b00: countdown_value <= {24'd0, data_in[7:0]};
+                            2'b01: countdown_value <= {16'd0, data_in[15:0]};
+                            2'b10: countdown_value <= data_in;
+                            default:  /* do nothing */;
+                        endcase
+                    end
+
+                    ADDR_TAP: begin  // Tap
+                        if (enabled && started && data_in == TAP_MAGIC) begin
+                            counter <= countdown_value;
+                            timeout_pending <= 1'b0;
+                        end
+                    end
+
+                    default:  /* do nothing */;
+                endcase
+            end
+        end
+    end
+
+    // ------------------------------------------------------------------------
+    // Read Handling
+    // ------------------------------------------------------------------------
+    always_ff @(posedge clk) begin
+        data_ready_reg <= (data_read_n != 2'b11);
+        unique case (address)
+            ADDR_COUNTDOWN: data_reg <= countdown_value;
+            ADDR_STATUS:    data_reg <= {28'd0, (counter != 0), timeout_pending, started, enabled};
+            default:        data_reg <= 32'hFFFFFFFF;
+        endcase
+    end
+
+    // ------------------------------------------------------------------------
+    // Outputs
+    // ------------------------------------------------------------------------
+    assign uo_out = 8'd0;  // Not used
+    assign data_out = data_reg;
+    assign data_ready = data_ready_reg;
+    assign user_interrupt = timeout_pending;
+
+    // List all unused inputs to prevent warnings
+    // ui_in is unused as none of our behaviour depends on
+    // PMOD input.
+    wire _unused = &{ui_in, 1'b0};
+
+endmodule

--- a/test/Makefile
+++ b/test/Makefile
@@ -11,6 +11,7 @@ USER_PERIPHERALS = \
     test_spike  \
 	fpu.test \
 	baby_vga.test \
+	wdt.test \
 
 .PHONY: all $(USER_PERIPHERALS)
 

--- a/test/user_peripherals/wdt/test.py
+++ b/test/user_peripherals/wdt/test.py
@@ -1,0 +1,354 @@
+# SPDX-FileCopyrightText: © 2025 Tiny Tapeout
+# SPDX-License-Identifier: Apache-2.0
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import ClockCycles
+
+from tqv import TinyQV
+
+PERIPHERAL_NUM = 6
+CLK_PERIOD_NS = 100  # 10 MHz test clock (instead of 64 MHz)
+
+# The TAP magic number is used to reset the watchdog timer and prevent firing of an interrupt.
+# It is defined in the peripheral's source code.
+TAP_MAGIC = 0xABCD
+TAP_INVALID = 0xFFFF
+LARGE_COUNTDOWN = 0x12345678
+WDT_ADDR = {
+    "enable":     0,  # Write 1 to enable, 0 to disable (also clears interrupt)
+    "start":      1,  # Write 1 to start timer (implicitly enables)
+    "countdown":  2,  # R/W 8/16/32-bit countdown value
+    "tap":        3,  # Write 0xABCD to reset countdown and clear interrupt
+    "status":     4,  # Read status register
+}
+
+
+def decode_wdt_status(status_word: int) -> dict:
+    """
+    Decode the WDT status register into named boolean flags.
+
+    Bit layout:
+      Bit 0: enabled
+      Bit 1: started
+      Bit 2: timeout_pending
+      Bit 3: counter_active (counter != 0)
+    """
+    return {
+        "enabled":         bool((status_word >> 0) & 1),
+        "started":         bool((status_word >> 1) & 1),
+        "timeout_pending": bool((status_word >> 2) & 1),
+        "counter_active":  bool((status_word >> 3) & 1),
+    }
+
+
+@cocotb.test()
+async def test_watchdog_interrupt_on_timeout(dut):
+    """Basic test to check that the watchdog timer asserts an interrupt on timeout."""
+    clock = Clock(dut.clk, CLK_PERIOD_NS, units="ns")
+    cocotb.start_soon(clock.start())
+    tqv = TinyQV(dut, PERIPHERAL_NUM)
+    await tqv.reset()
+
+    countdown_ticks = 10  # enough to count down in test environment
+
+    # Set countdown value
+    await tqv.write_word_reg(WDT_ADDR["countdown"], countdown_ticks)
+
+    # Start the watchdog
+    await tqv.write_word_reg(WDT_ADDR["start"], 1)
+
+    # Wait for timeout (countdown_ticks + a few cycles)
+    await ClockCycles(dut.clk, countdown_ticks + 3)
+
+    assert await tqv.is_interrupt_asserted(), "Interrupt not asserted on timeout"
+
+
+@cocotb.test()
+async def test_watchdog_tap_prevents_timeout(dut):
+    """Basic test to check that tapping the watchdog prevents an interrupt."""
+    clock = Clock(dut.clk, CLK_PERIOD_NS, units="ns")
+    cocotb.start_soon(clock.start())
+    tqv = TinyQV(dut, PERIPHERAL_NUM)
+    await tqv.reset()
+
+    countdown_ticks = 100
+
+    # Set countdown
+    await tqv.write_word_reg(WDT_ADDR["countdown"], countdown_ticks)
+    await tqv.write_word_reg(WDT_ADDR["start"], 1)
+
+    # Wait until we have confirmed an interrupt has been asserted
+    await ClockCycles(dut.clk, countdown_ticks)
+    assert await tqv.is_interrupt_asserted(), "Interrupt not asserted on timeout"
+
+    # Tap the watchdog to reset countdown and clear interrupt
+    await tqv.write_word_reg(WDT_ADDR["tap"], TAP_MAGIC)
+
+    # Wait again a few cycles and then check that the interrupt is not asserted
+    await ClockCycles(dut.clk, countdown_ticks // 4)
+
+    assert not await tqv.is_interrupt_asserted(), "Interrupt incorrectly asserted after tap"
+
+
+@cocotb.test()
+async def test_enable_does_not_clear_timeout(dut):
+    """Writing 0 to enable register should NOT clear a pending timeout."""
+    clock = Clock(dut.clk, CLK_PERIOD_NS, units="ns")
+    cocotb.start_soon(clock.start())
+    tqv = TinyQV(dut, PERIPHERAL_NUM)
+    await tqv.reset()
+
+    countdown_ticks = 10
+
+    # Set countdown
+    await tqv.write_word_reg(WDT_ADDR["countdown"], countdown_ticks)
+    await tqv.write_word_reg(WDT_ADDR["start"], 1)
+
+    # Wait until we have confirmed an interrupt has been asserted
+    await ClockCycles(dut.clk, countdown_ticks)
+    assert await tqv.is_interrupt_asserted(), "Interrupt not asserted on timeout"
+
+    await tqv.write_word_reg(WDT_ADDR["enable"], 0)
+
+    assert await tqv.is_interrupt_asserted(), "Interrupt cleared by enable write of zero"
+
+
+@cocotb.test()
+async def test_multiple_valid_taps_prevent_interrupt(dut):
+    """Multiple correct taps should keep reloading the countdown and prevent timeout."""
+    clock = Clock(dut.clk, CLK_PERIOD_NS, units="ns")
+    cocotb.start_soon(clock.start())
+    tqv = TinyQV(dut, PERIPHERAL_NUM)
+    await tqv.reset()
+
+    countdown_ticks = 100
+
+    # Set countdown
+    await tqv.write_word_reg(WDT_ADDR["countdown"], countdown_ticks)
+    await tqv.write_word_reg(WDT_ADDR["start"], 1)
+
+    # Tap the watchdog multiple times within countdown period.
+    # The total cycles exceeds countdown_ticks, but the taps should prevent the interrupt.
+    await tqv.write_word_reg(WDT_ADDR["tap"], TAP_MAGIC)
+    await ClockCycles(dut.clk, countdown_ticks // 2)
+
+    await tqv.write_word_reg(WDT_ADDR["tap"], TAP_MAGIC)
+    await ClockCycles(dut.clk, countdown_ticks // 2)
+
+    assert not await tqv.is_interrupt_asserted(), "Interrupt incorrectly asserted after valid taps"
+
+
+@cocotb.test()
+async def test_tap_with_wrong_value_ignored(dut):
+    """Writing incorrect value to tap address should have no effect (timeout occurs)."""
+    clock = Clock(dut.clk, CLK_PERIOD_NS, units="ns")
+    cocotb.start_soon(clock.start())
+    tqv = TinyQV(dut, PERIPHERAL_NUM)
+    await tqv.reset()
+
+    countdown_ticks = 100
+
+    # Set countdown
+    await tqv.write_word_reg(WDT_ADDR["countdown"], countdown_ticks)
+    await tqv.write_word_reg(WDT_ADDR["start"], 1)
+
+    # Wait until we have confirmed an interrupt has been asserted
+    await ClockCycles(dut.clk, countdown_ticks)
+    assert await tqv.is_interrupt_asserted(), "Interrupt not asserted on timeout"
+
+    # Tap the watchdog with valid number, should *not* reset countdown and clear interrupt
+    await tqv.write_word_reg(WDT_ADDR["tap"], TAP_INVALID)
+
+    # Wait again a few cycles and then check that the interrupt is still asserted
+    await ClockCycles(dut.clk, countdown_ticks // 4)
+
+    assert await tqv.is_interrupt_asserted(), "Interrupt cleared by invalid tap"
+
+
+@cocotb.test()
+async def test_start_does_not_clear_interrupt(dut):
+    """Writes to 'start' should not clear timeout."""
+    clock = Clock(dut.clk, CLK_PERIOD_NS, units="ns")
+    cocotb.start_soon(clock.start())
+    tqv = TinyQV(dut, PERIPHERAL_NUM)
+    await tqv.reset()
+
+    countdown_ticks = 50
+
+    # Set countdown
+    await tqv.write_word_reg(WDT_ADDR["countdown"], countdown_ticks)
+    await tqv.write_word_reg(WDT_ADDR["start"], 1)
+
+    await ClockCycles(dut.clk, countdown_ticks)
+
+    assert await tqv.is_interrupt_asserted(), "Interrupt not asserted on timeout"
+
+    # Writing to start should reload the counter, but not clear any existing interrupt
+    await tqv.write_word_reg(WDT_ADDR["start"], 1)
+
+    assert await tqv.is_interrupt_asserted(), "Write to start incorrectly cleared interrupt"
+
+
+@cocotb.test()
+async def test_repeated_start_reloads_countdown(dut):
+    """Multiple writes to 'start' should reload countdown."""
+    clock = Clock(dut.clk, CLK_PERIOD_NS, units="ns")
+    cocotb.start_soon(clock.start())
+    tqv = TinyQV(dut, PERIPHERAL_NUM)
+    await tqv.reset()
+
+    countdown_ticks = 400
+
+    # Set countdown
+    await tqv.write_word_reg(WDT_ADDR["countdown"], countdown_ticks)
+    await tqv.write_word_reg(WDT_ADDR["start"], 1)
+
+    # Wait 1/4 of the countdown, write to start, wait the rest of the countdown time and check interrupt not asserted
+    # NOTE: The write_word_reg takes enough cycles that it is too slow to call the write when half of the
+    # countdown period has elapse.
+    await ClockCycles(dut.clk, countdown_ticks // 4)
+    await tqv.write_word_reg(WDT_ADDR["start"], 1)
+
+    await ClockCycles(dut.clk, 3 * (countdown_ticks // 4))
+
+    assert not await tqv.is_interrupt_asserted(), "Write to start did not reload countdown"
+
+
+@cocotb.test()
+async def test_countdown_value_readback(dut):
+    """Read from countdown address should return last written value."""
+    clock = Clock(dut.clk, CLK_PERIOD_NS, units="ns")
+    cocotb.start_soon(clock.start())
+    tqv = TinyQV(dut, PERIPHERAL_NUM)
+    await tqv.reset()
+
+    countdown_ticks = LARGE_COUNTDOWN
+
+    await tqv.write_word_reg(WDT_ADDR["countdown"], countdown_ticks)
+    readback = await tqv.read_word_reg(WDT_ADDR["countdown"])
+    assert readback == countdown_ticks, f"Expected 0x{countdown_ticks:08X}, got 0x{readback:08X}"
+
+
+@cocotb.test()
+async def test_partial_write_8bit_zeros_upper_bits(dut):
+    """8-bit write to countdown should zero upper 24 bits."""
+    clock = Clock(dut.clk, CLK_PERIOD_NS, units="ns")
+    cocotb.start_soon(clock.start())
+    tqv = TinyQV(dut, PERIPHERAL_NUM)
+    await tqv.reset()
+
+    # Set to known large value first
+    await tqv.write_word_reg(WDT_ADDR["countdown"], LARGE_COUNTDOWN)
+
+    # Now write only the low 8 bits
+    await tqv.write_byte_reg(WDT_ADDR["countdown"], 0x42)
+
+    readback = await tqv.read_word_reg(WDT_ADDR["countdown"])
+    assert readback == 0x00000042, f"Expected 0x00000042, got 0x{readback:08X}"
+
+
+@cocotb.test()
+async def test_partial_write_16bit_zeros_upper_bits(dut):
+    """16-bit write to countdown should zero upper 16 bits."""
+    clock = Clock(dut.clk, CLK_PERIOD_NS, units="ns")
+    cocotb.start_soon(clock.start())
+    tqv = TinyQV(dut, PERIPHERAL_NUM)
+    await tqv.reset()
+
+    # Set to known large value first
+    await tqv.write_word_reg(WDT_ADDR["countdown"], LARGE_COUNTDOWN)
+
+    # Now write only the low 16 bits
+    await tqv.write_hword_reg(WDT_ADDR["countdown"], 0xFFFF)
+
+    readback = await tqv.read_word_reg(WDT_ADDR["countdown"])
+    assert readback == 0x0000FFFF, f"Expected 0x0000BEEF, got 0x{readback:08X}"
+
+
+@cocotb.test()
+async def test_start_without_countdown_value(dut):
+    """Starting the watchdog without setting countdown should not start the timer."""
+    clock = Clock(dut.clk, CLK_PERIOD_NS, units="ns")
+    cocotb.start_soon(clock.start())
+    tqv = TinyQV(dut, PERIPHERAL_NUM)
+    await tqv.reset()
+
+    # Do not set countdown, just issue start
+    await tqv.write_word_reg(WDT_ADDR["start"], 1)
+
+    # Read status register
+    status_word = await tqv.read_word_reg(WDT_ADDR["status"])
+    status = decode_wdt_status(status_word)
+
+    assert not status["enabled"], "Status: expected enabled=0 without countdown"
+    assert not status["started"], "Status: expected started=0 without countdown"
+    assert not status["timeout_pending"], "Status: expected timeout_pending=0"
+    assert not status["counter_active"], "Status: expected counter=0"
+
+
+@cocotb.test()
+async def test_status_after_start(dut):
+    """Status register reflects enabled=1, started=1, counter!=0 before timeout."""
+    clock = Clock(dut.clk, CLK_PERIOD_NS, units="ns")
+    cocotb.start_soon(clock.start())
+    tqv = TinyQV(dut, PERIPHERAL_NUM)
+    await tqv.reset()
+
+    countdown_ticks = 200
+
+    # Set countdown and start the watchdog
+    await tqv.write_word_reg(WDT_ADDR["countdown"], countdown_ticks)
+    await tqv.write_word_reg(WDT_ADDR["start"], 1)
+
+    # Read the status register
+    status_word = await tqv.read_word_reg(WDT_ADDR["status"])
+    status = decode_wdt_status(status_word)
+
+    assert status["enabled"], "Status: expected enabled=1"
+    assert status["started"], "Status: expected started=1"
+    assert not status["timeout_pending"], "Status: expected timeout_pending=0"
+    assert status["counter_active"], "Status: expected counter!=0"
+
+
+@cocotb.test()
+async def test_status_after_timeout(dut):
+    """Status register reflects timeout_pending=1 after timer expiry."""
+    clock = Clock(dut.clk, CLK_PERIOD_NS, units="ns")
+    cocotb.start_soon(clock.start())
+    tqv = TinyQV(dut, PERIPHERAL_NUM)
+    await tqv.reset()
+
+    countdown_ticks = 10
+
+    # Set countdown and start the watchdog
+    await tqv.write_word_reg(WDT_ADDR["countdown"], countdown_ticks)
+    await tqv.write_word_reg(WDT_ADDR["start"], 1)
+
+    await ClockCycles(dut.clk, countdown_ticks)
+    assert await tqv.is_interrupt_asserted(), "Interrupt not asserted on timeout"
+
+    # Read the status register
+    status_word = await tqv.read_word_reg(WDT_ADDR["status"])
+    status = decode_wdt_status(status_word)
+
+    assert status["enabled"], "Status: expected enabled=1 after timeout"
+    assert status["started"], "Status: expected started=1 after timeout"
+    assert status["timeout_pending"], "Status: expected timeout_pending=1 after timeout"
+    assert not status["counter_active"], "Status: expected counter=0 after timeout"
+
+
+@cocotb.test()
+async def test_disable_before_start_has_no_effect(dut):
+    """Disabling before watchdog is started should have no effect and not assert interrupt."""
+    clock = Clock(dut.clk, CLK_PERIOD_NS, units="ns")
+    cocotb.start_soon(clock.start())
+    tqv = TinyQV(dut, PERIPHERAL_NUM)
+    await tqv.reset()
+
+    # Write 0 to disable (has no effect before start)
+    await tqv.write_word_reg(WDT_ADDR["enable"], 0)
+
+    # Wait a few cycles and confirm no spurious interrupt
+    await ClockCycles(dut.clk, 10)
+    assert not await tqv.is_interrupt_asserted(), "Unexpected interrupt before WDT was started"


### PR DESCRIPTION
Link to your peripheral repo: https://github.com/nkanderson/tinyqv-full-peripheral-wdt

I saw that a watchdog timer was listed an one of the peripheral ideas on discord, so thought I'd give it a go. I was hoping to get some feedback before moving this from a draft to regular PR though. Specifically, I'm wondering about the following:
- This functionality could very likely fit in the byte peripheral template (if we add a prescaler to the countdown value), but there is no `user_interrupt` signal in that template, which seems fairly critical for a watchdog timer. Is this the best template to use, or should I try to move this to the byte peripheral?
- Is this the general functionality that is desired for a watchdog timer? One specific item is the enable address, which is somewhat redundant given the start one-shot functionality. This is my first attempted contribution to a TinyTapeout, and I'm new to ASIC development more generally, so any feedback is helpful. 