### PR TITLE
ledstrip peripheral: remove warning in character ROM synthesis

### DIFF
--- a/src/user_peripherals/ledstrip/char_rom.v
+++ b/src/user_peripherals/ledstrip/char_rom.v
@@ -8,8 +8,9 @@ module char_rom #(
     output wire [DATA_WIDTH-1:0] data
 );
 
-reg [DATA_WIDTH-1:0] d;
+wire [DATA_WIDTH-1:0] d;
 
+// a permutation of signals that allows the character ROM to be synthesized using fewer gates
 assign data = { d[6], d[16], d[5], d[9], d[10], d[20], d[33], d[7], d[27], d[8], d[2], d[23], d[30], d[15], d[34], d[11], d[1], d[22], d[31], d[3], d[18], d[28], d[4], d[14], d[0], d[12], d[25], d[13], d[17], d[29], d[19], d[26], d[21], d[24], d[32] };
 
 reg [DATA_WIDTH-1:0] mem [0:ADDR_MAX-ADDR_MIN];


### PR DESCRIPTION
A "reg" that should have been a "wire" in `src/user_peripherals/ledstrip/char_rom.v`.