### PR TITLE
NPU: fix sw baseline doing acc in int32

### DIFF
--- a/test/user_peripherals/npu/test.py
+++ b/test/user_peripherals/npu/test.py
@@ -45,10 +45,10 @@ async def test_project(dut):
 
     for _ in range(10):
         relu, output_zp, shamts = bool(random.getrandbits(1)), random.randint(-8, 7), np.random.randint(0, 31, size=(NCOLS,))
-        bias = np.random.randint(*dtype_to_bounds(ACC_WIDTH, True), size=(NCOLS,))
-        qmuls = np.random.randint(10000, (1 << ACC_WIDTH - 1) - 1, size=(NCOLS,))
-        w = np.random.randint(*dtype_to_bounds(4, True), size=(NROWS, NCOLS))
-        a = np.random.randint(*dtype_to_bounds(4, True), size=(1, NROWS))
+        bias = np.random.randint(*dtype_to_bounds(ACC_WIDTH, True), size=(NCOLS,), dtype=np.int16)
+        qmuls = np.random.randint(0, (1 << ACC_WIDTH - 1) - 1, size=(NCOLS,), dtype=np.int16)
+        w = np.random.randint(*dtype_to_bounds(4, True), size=(NROWS, NCOLS), dtype=np.int8)
+        a = np.random.randint(*dtype_to_bounds(4, True), size=(1, NROWS), dtype=np.int8)
         expected = qfc(a, w, bias, output_zp, qmuls, shamts, relu=relu, width=4, signed=True)
         np.testing.assert_array_equal(await tb_qfc(tqv, a, w, bias, output_zp, qmuls, shamts,
             nrows=NROWS, ncols=NCOLS, acc_width=ACC_WIDTH, relu=relu, progress=False), expected)

--- a/test/user_peripherals/npu/utils.py
+++ b/test/user_peripherals/npu/utils.py
@@ -111,7 +111,7 @@ def tiled(x, *tile_shape):
 def dtype_to_bounds(width, signed): return (-1 << width - 1, (1 << width - 1) - 1) if signed else (0, (1 << width) - 1)
 
 def qfc(input, weight, bias, output_zp, qmul, shamt, relu=True, width=4, signed=True):
-    out = input.astype(np.int32) @ weight + bias
+    out = input.astype(np.int16) @ weight.astype(np.int16) + bias.astype(np.int16)
     out = np.maximum(out, 0) if relu else out
     out = (qmul.astype(np.int32) * out >> shamt) + output_zp
     return np.clip(out, *dtype_to_bounds(width, signed)).astype(np.int8)


### PR DESCRIPTION
The software baseline was still doing accumulation in int32 instead of int16 like the peripheral